### PR TITLE
Fix CrossOperator does not work

### DIFF
--- a/flink-addons/flink-language-binding/src/main/python/org/apache/flink/languagebinding/api/python/flink/plan/DataSet.py
+++ b/flink-addons/flink-language-binding/src/main/python/org/apache/flink/languagebinding/api/python/flink/plan/DataSet.py
@@ -695,8 +695,8 @@ class CrossOperator(object):
     def __init__(self, ref, dic):
         self._ref = ref
         self._dic = dic
-        self._dic[_Fields.PKEY1] = []
-        self._dic[_Fields.PKEY2] = []
+        self._dic[_Fields.PKEY1] = None
+        self._dic[_Fields.PKEY2] = None
         self._dic[_Fields.OPERATOR] = []
         self._dic[_Fields.META] = []
 


### PR DESCRIPTION
The 2 empty lists  become "16" and null in the `PythonExecutor`. I don't know where does this 16 come from :-(
